### PR TITLE
Fixed tests after angular 5 upgrade.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ config.codekit3
 node_modules/
 dist/
 .vscode/
+.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -213,6 +213,15 @@
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
+        "source-map-support": {
+          "version": "0.4.18",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.7"
+          }
+        },
         "supports-color": {
           "version": "4.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
@@ -9782,6 +9791,15 @@
             "pinkie-promise": "2.0.1"
           }
         },
+        "source-map-support": {
+          "version": "0.4.18",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.7"
+          }
+        },
         "webdriver-manager": {
           "version": "12.1.0",
           "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.1.0.tgz",
@@ -11258,12 +11276,21 @@
       }
     },
     "source-map-support": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+      "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "buffer-from": "1.1.1",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "source-map-url": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "protractor": "~5.4.0",
     "ts-node": "~6.2.0",
     "tslint": "~5.11.0",
-    "typescript": "2.6.2"
+    "typescript": "2.6.2",
+    "source-map-support": "0.5.9"
   }
 }

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, async } from '@angular/core/testing'
+import { async, TestBed } from '@angular/core/testing'
 import { RouterTestingModule } from '@angular/router/testing'
 import { HttpClientModule } from '@angular/common/http'
 
@@ -6,13 +6,20 @@ import { ProfileService } from './service/profile.service'
 import { AuthService } from './service/auth.service'
 
 import { AppComponent } from './app.component'
+import { TranslateFakeLoader, TranslateLoader, TranslateModule } from "@ngx-translate/core";
 
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
         RouterTestingModule,
-        HttpClientModule
+        HttpClientModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useFactory: () => new TranslateFakeLoader()
+          }
+        })
       ],
       declarations: [
         AppComponent

--- a/src/app/code/code.component.spec.ts
+++ b/src/app/code/code.component.spec.ts
@@ -4,9 +4,10 @@ import { FormsModule } from '@angular/forms'
 import { HttpClientModule } from '@angular/common/http'
 
 import { TaskService } from '../service/task.service'
-import { MockComponent, TaskServiceMock } from '../../tests/mocks.spec'
+import { TaskServiceMock } from '../../tests/mocks.spec'
 
 import { CodeComponent } from './code.component';
+import { TranslateFakeLoader, TranslateLoader, TranslateModule } from "@ngx-translate/core";
 
 describe('CodeComponent', () => {
   let component: CodeComponent;
@@ -14,17 +15,23 @@ describe('CodeComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ CodeComponent ],
+      declarations: [CodeComponent],
       imports: [
         FormsModule,
         HttpClientModule,
-        RouterTestingModule
+        RouterTestingModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useFactory: () => new TranslateFakeLoader()
+          }
+        })
       ],
       providers: [
-        { provide: TaskService, useClass: TaskServiceMock }
+        { provide: TaskService, useClass: TaskServiceMock },
       ]
     })
-    .compileComponents()
+      .compileComponents()
   }))
 
   beforeEach(() => {

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -1,5 +1,3 @@
-import { User, Role } from '../service/model'
-import { Component } from '@angular/core'
 import { async, ComponentFixture, TestBed } from '@angular/core/testing'
 import { RouterTestingModule } from '@angular/router/testing'
 import { FormsModule } from '@angular/forms'
@@ -10,9 +8,13 @@ import { TaskService } from '../service/task.service'
 import { ProfileService } from '../service/profile.service'
 import { ConversionService } from '../service/conversion.service'
 import { CodeComponent } from '../code/code.component'
-import { MockComponent, AuthServiceMock, TaskServiceMock } from '../../tests/mocks.spec'
+import { AuthServiceMock, TaskServiceMock } from '../../tests/mocks.spec'
 
 import { DashboardComponent } from './dashboard.component'
+import { MockComponent } from "../../tests/mock.component";
+import { TranslateFakeLoader, TranslateLoader, TranslateModule } from "@ngx-translate/core";
+import { DeleteTaskComponent } from "../delete-task/delete-task.component";
+import { LanguagePipe } from "../pipe/language.pipe";
 
 describe('DashboardComponent', () => {
   let component: DashboardComponent
@@ -20,10 +22,16 @@ describe('DashboardComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ DashboardComponent, CodeComponent, MockComponent ],
+      declarations: [DashboardComponent, CodeComponent, DeleteTaskComponent, LanguagePipe, MockComponent],
       imports: [
         FormsModule,
         HttpClientModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useFactory: () => new TranslateFakeLoader()
+          }
+        }),
         RouterTestingModule.withRoutes([
           { path: 'map/:id', component: MockComponent }
         ])
@@ -35,7 +43,7 @@ describe('DashboardComponent', () => {
         ConversionService
       ]
     })
-    .compileComponents()
+      .compileComponents()
   }))
 
   beforeEach(() => {

--- a/src/app/delete-task-template/delete-task-template.component.spec.ts
+++ b/src/app/delete-task-template/delete-task-template.component.spec.ts
@@ -5,26 +5,32 @@ import { DeleteTaskTemplateComponent } from './delete-task-template.component';
 
 import { HttpClientModule } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
 
 import { TestMethods } from '../../tests/mocks.spec'
+import { TranslateFakeLoader, TranslateLoader, TranslateModule } from "@ngx-translate/core";
 
-describe('TaskTemplateComponent', () => {
+describe('DeleteTaskTemplateComponent', () => {
   let component: DeleteTaskTemplateComponent;
   let fixture: ComponentFixture<DeleteTaskTemplateComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ DeleteTaskTemplateComponent ],
+      declarations: [DeleteTaskTemplateComponent],
       imports: [
         FormsModule,
-        HttpClientModule
+        HttpClientModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useFactory: () => new TranslateFakeLoader()
+          }
+        })
       ],
       providers: [
         TaskTemplateService
       ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -1,12 +1,12 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing'
 import { RouterTestingModule } from '@angular/router/testing'
 import { HttpClientModule } from '@angular/common/http'
-import { Router } from '@angular/router'
 
 import { AuthService } from '../service/auth.service'
-import { MockComponent, AuthServiceMock } from '../../tests/mocks.spec'
+import { AuthServiceMock } from '../../tests/mocks.spec'
 
 import { HomeComponent } from './home.component'
+import { MockComponent } from "../../tests/mock.component";
 
 describe('HomeComponent', () => {
   let component: HomeComponent
@@ -14,7 +14,7 @@ describe('HomeComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ HomeComponent, MockComponent ],
+      declarations: [HomeComponent, MockComponent],
       imports: [
         HttpClientModule,
         RouterTestingModule.withRoutes([
@@ -25,7 +25,7 @@ describe('HomeComponent', () => {
         { provide: AuthService, useClass: AuthServiceMock }
       ]
     })
-    .compileComponents()
+      .compileComponents()
   }))
 
   beforeEach(() => {

--- a/src/app/library/library.component.spec.ts
+++ b/src/app/library/library.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing'
 import { FormsModule } from '@angular/forms'
 import { RouterTestingModule } from '@angular/router/testing'
 
-import { AuthServiceMock, MockComponent, TaskServiceMock, TaskTemplateServiceMock } from '../../tests/mocks.spec'
+import { AuthServiceMock, TaskServiceMock, TaskTemplateServiceMock } from '../../tests/mocks.spec'
 import { AuthService } from '../service/auth.service'
 import { TaskTemplateService } from '../service/task-template.service'
 import { TaskService } from '../service/task.service'
@@ -12,6 +12,10 @@ import { TruncatePipe } from '../pipe/truncate.pipe'
 import { TaskTemplateComponent } from '../task-template/task-template.component'
 import { DeleteTaskTemplateComponent } from '../delete-task-template/delete-task-template.component'
 import { LibraryComponent } from './library.component'
+import { MockComponent } from "../../tests/mock.component";
+import { TranslateFakeLoader, TranslateLoader, TranslateModule } from "@ngx-translate/core";
+import { LineBreakPipe } from "../pipe/line-break.pipe";
+import { QuillModule } from "ngx-quill";
 
 describe('LibraryComponent', () => {
   let component: LibraryComponent
@@ -19,10 +23,18 @@ describe('LibraryComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ TruncatePipe, LibraryComponent, MockComponent, TaskTemplateComponent, DeleteTaskTemplateComponent ],
+      declarations: [TruncatePipe, LineBreakPipe, LibraryComponent, MockComponent,
+        TaskTemplateComponent, DeleteTaskTemplateComponent],
       imports: [
         FormsModule,
         HttpClientModule,
+        QuillModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useFactory: () => new TranslateFakeLoader()
+          }
+        }),
         RouterTestingModule.withRoutes([
           { path: 'map', component: MockComponent }
         ])
@@ -34,7 +46,7 @@ describe('LibraryComponent', () => {
         ConversionService
       ]
     })
-    .compileComponents()
+      .compileComponents()
   }))
 
   beforeEach(() => {

--- a/src/app/map/help.component.spec.ts
+++ b/src/app/map/help.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing'
 import { HelpComponent } from './help.component'
+import { TranslateFakeLoader, TranslateLoader, TranslateModule } from "@ngx-translate/core";
 
 describe('HelpComponent', () => {
   let component: HelpComponent
@@ -7,7 +8,15 @@ describe('HelpComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [HelpComponent]
+      declarations: [HelpComponent],
+      imports: [
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useFactory: () => new TranslateFakeLoader()
+          }
+        })
+      ]
     })
       .compileComponents()
   }))

--- a/src/app/map/map.component.html
+++ b/src/app/map/map.component.html
@@ -6,6 +6,6 @@
             <a (click)="showHelp()" class="view__header-link type--info">{{'map.instructions' | translate}}</a>
         </div>
     </div>
-    <app-oskari-rpc (markerOpened)="isMarkerVisible = true" (markerClosed)="isMarkerVisible = false" [task]="task"></app-oskari-rpc>
+    <app-oskari-rpc *ngIf="task" (markerOpened)="isMarkerVisible = true" (markerClosed)="isMarkerVisible = false" [task]="task"></app-oskari-rpc>
 </div>
 <app-help (helpClosed)="hideHelp()" [task]="task" [visible]="isHelpVisible"></app-help>

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -1,14 +1,9 @@
 import 'rxjs/add/operator/switchMap'
-import * as GeoJSON from 'geojson'
-import { Component, OnInit, Input } from '@angular/core'
+import { Component, Input, OnInit } from '@angular/core'
 import { ActivatedRoute, ParamMap, Router } from '@angular/router'
 import { environment } from '../../environments/environment'
-import { OskariRpcComponent } from './oskari-rpc.component'
-import { HelpComponent } from './help.component'
 import { TaskService } from '../service/task.service'
-import { TaskTemplateService } from '../service/task-template.service'
-import { Task, ResultItem, Geometry } from '../service/model'
-import { Result } from '../service/model-result'
+import { Task } from '../service/model'
 
 @Component({
   selector: 'app-map',
@@ -21,21 +16,20 @@ export class MapComponent implements OnInit {
   task: Task
   @Input() helpClosed: () => boolean
 
-  constructor(private taskService: TaskService, private route: ActivatedRoute, private router: Router,
-    private taskTemplateService: TaskTemplateService) {
+  constructor(private taskService: TaskService, private route: ActivatedRoute, private router: Router) {
   }
 
   ngOnInit(): void {
     this.route.paramMap
       .switchMap((params: ParamMap) => this.taskService.getTask(+params.get('id'), true, true))
       .subscribe(task => {
-        this.task = task
-      },
-      error => {
-        console.error('Failed get task')
-        console.error(error)
-        if (error.status === 404) this.router.navigate(['/dashboard'])
-      })
+          this.task = task
+        },
+        error => {
+          console.error('Failed get task')
+          console.error(error)
+          if (error.status === 404) this.router.navigate(['/dashboard'])
+        })
   }
 
   showHelp() {

--- a/src/app/map/result/result-item.component.spec.ts
+++ b/src/app/map/result/result-item.component.spec.ts
@@ -1,4 +1,3 @@
-import { Component } from '@angular/core'
 import { async, ComponentFixture, TestBed } from '@angular/core/testing'
 import { RouterTestingModule } from '@angular/router/testing'
 import { FormsModule } from '@angular/forms'
@@ -9,10 +8,12 @@ import { Ng2PicaModule } from 'ng2-pica'
 import { DecimalPipe } from '../../pipe/decimal.pipe'
 import { AuthService } from '../../service/auth.service'
 import { GeoService } from '../geo.service'
-import { MockComponent, AuthServiceMock } from '../../../tests/mocks.spec'
 import { ResultItemComponent } from './result-item.component'
 import { AttachmentService } from '../../service/attachment.service'
 import { ResizeService } from '../../service/resize.service'
+import { MockComponent } from "../../../tests/mock.component";
+import { AuthServiceMock } from "../../../tests/mocks.spec";
+import { TranslateFakeLoader, TranslateLoader, TranslateModule } from "@ngx-translate/core";
 
 describe('ResultItemComponent', () => {
   let component: ResultItemComponent
@@ -20,12 +21,18 @@ describe('ResultItemComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ ResultItemComponent, MockComponent, DecimalPipe ],
+      declarations: [ResultItemComponent, MockComponent, DecimalPipe],
       imports: [
         FormsModule,
         HttpClientModule,
         FileUploadModule,
         Ng2PicaModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useFactory: () => new TranslateFakeLoader()
+          }
+        }),
         RouterTestingModule.withRoutes([
           { path: 'map', component: MockComponent }
         ])
@@ -37,7 +44,7 @@ describe('ResultItemComponent', () => {
         ResizeService
       ]
     })
-    .compileComponents()
+      .compileComponents()
   }))
 
   beforeEach(() => {

--- a/src/app/message/message.component.spec.ts
+++ b/src/app/message/message.component.spec.ts
@@ -1,9 +1,10 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing'
 import { RouterTestingModule } from '@angular/router/testing'
 
-import { MockComponent } from '../../tests/mocks.spec'
 import { MessageService } from './message.service'
 import { MessageComponent } from './message.component'
+import { MockComponent } from "../../tests/mock.component";
+import { MocksModule } from "../../tests/mocks.module";
 
 describe('MessageComponent', () => {
   let component: MessageComponent
@@ -11,8 +12,9 @@ describe('MessageComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ MessageComponent, MockComponent ],
+      declarations: [MessageComponent],
       imports: [
+        MocksModule,
         RouterTestingModule.withRoutes([
           { path: 'map', component: MockComponent }
         ])
@@ -21,7 +23,7 @@ describe('MessageComponent', () => {
         MessageService
       ]
     })
-    .compileComponents()
+      .compileComponents()
   }))
 
   beforeEach(() => {

--- a/src/app/message/message.service.spec.ts
+++ b/src/app/message/message.service.spec.ts
@@ -1,8 +1,8 @@
 import { TestBed, inject } from '@angular/core/testing'
 import { RouterTestingModule } from '@angular/router/testing'
 
-import { MockComponent } from '../../tests/mocks.spec'
 import { MessageService } from './message.service'
+import { MockComponent } from "../../tests/mock.component";
 
 describe('MessageService', () => {
   beforeEach(() => {

--- a/src/app/service/auth.service.spec.ts
+++ b/src/app/service/auth.service.spec.ts
@@ -1,8 +1,8 @@
-import { TestBed, async, inject } from '@angular/core/testing'
+import { inject, TestBed } from '@angular/core/testing'
 import { HttpClientModule } from '@angular/common/http'
 import { RouterTestingModule } from '@angular/router/testing'
 
-import { MockComponent } from '../../tests/mocks.spec'
+import { MockComponent } from '../../tests/mock.component'
 import { AuthService } from './auth.service'
 
 describe('AuthService', () => {

--- a/src/app/service/model.ts
+++ b/src/app/service/model.ts
@@ -25,7 +25,7 @@ export interface User {
 /**
  * `TaskTemplate` is a template for a task, which contain all information about the `Task`.
  * `TaskTemplate` can be instantiated as a `Task`, and then code is generated for the `Task`.
- * All students in the class will perform the same `Task` instance. 
+ * All students in the class will perform the same `Task` instance.
  * When students save their results they will add a `Result` to the `Task` with their userId.
  * Each student has their own `Result` which groups all the answers together.
   */
@@ -74,6 +74,7 @@ export interface TaskDashboard {
     code: string
     creator: string
     resultItemCount: number
+    type: TaskType
 }
 
 export interface ResultItem {

--- a/src/app/service/task.service.spec.ts
+++ b/src/app/service/task.service.spec.ts
@@ -1,12 +1,12 @@
-import { TestBed, inject } from '@angular/core/testing'
+import { inject, TestBed } from '@angular/core/testing'
 import { HttpClientModule } from '@angular/common/http'
 import { RouterTestingModule } from '@angular/router/testing'
 
-import { MockComponent } from '../../tests/mocks.spec'
 import { TaskTemplateService } from './task-template.service'
 import { AuthService } from './auth.service'
 
 import { TaskService } from './task.service'
+import { MockComponent } from "../../tests/mock.component";
 
 describe('TaskService', () => {
   beforeEach(() => {

--- a/src/app/task-template/task-template.component.spec.ts
+++ b/src/app/task-template/task-template.component.spec.ts
@@ -9,7 +9,12 @@ import { OpsService } from '../service/ops.service';
 import { TaskTemplateComponent } from './task-template.component';
 import { TruncatePipe } from '../pipe/truncate.pipe'
 
-import { TestMethods, OpsServiceMock } from '../../tests/mocks.spec'
+import { AuthServiceMock, OpsServiceMock, TaskTemplateServiceMock, TestMethods } from '../../tests/mocks.spec'
+import { TranslateFakeLoader, TranslateLoader, TranslateModule } from "@ngx-translate/core";
+import { QuillModule } from "ngx-quill";
+import { LineBreakPipe } from "../pipe/line-break.pipe";
+import { AuthService } from "../service/auth.service";
+import { MockComponent } from "../../tests/mock.component";
 
 describe('TaskTemplateComponent', () => {
   let component: TaskTemplateComponent;
@@ -17,18 +22,27 @@ describe('TaskTemplateComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ TruncatePipe, TaskTemplateComponent ],
+      declarations: [TruncatePipe, TaskTemplateComponent, LineBreakPipe, MockComponent],
       imports: [
         RouterTestingModule,
         FormsModule,
-        HttpClientModule
+        HttpClientModule,
+        QuillModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useFactory: () => new TranslateFakeLoader()
+          }
+        })
       ],
       providers: [
         TaskTemplateService,
         { provide: OpsService, useClass: OpsServiceMock },
+        { provide: AuthService, useClass: AuthServiceMock },
+        { provide: TaskTemplateService, useClass: TaskTemplateServiceMock }
       ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/tests/mock.component.ts
+++ b/src/tests/mock.component.ts
@@ -1,0 +1,9 @@
+import { Component, OnInit } from "@angular/core";
+
+@Component({
+  template: '<div></div>'
+})
+export class MockComponent implements OnInit {
+  ngOnInit(): void {
+  }
+}

--- a/src/tests/mocks.module.ts
+++ b/src/tests/mocks.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from "@angular/core";
+import { MockComponent } from "./mock.component";
+
+@NgModule({
+  imports: [
+  ],
+  declarations: [
+    MockComponent
+  ],
+  exports: [
+    MockComponent
+  ]
+})
+export class MocksModule {
+}

--- a/src/tests/mocks.spec.ts
+++ b/src/tests/mocks.spec.ts
@@ -1,16 +1,10 @@
-import { Component } from '@angular/core'
 import { Observable } from 'rxjs/Observable'
 
-import { Grade, Role, Task, TaskDashboard, TaskTemplate, User } from '../app/service/model';
+import { Grade, Role, Task, TaskDashboard, TaskTemplate, TaskType, User, Visibility } from '../app/service/model';
+import { AuthService } from "../app/service/auth.service";
 
-@Component({
-  template: ''
-})
-export class MockComponent {
-}
+export class AuthServiceMock extends AuthService {
 
-export class AuthServiceMock {
-  
   getUser(): User | null {
     return TestMethods.getTeacher()
   }
@@ -42,7 +36,7 @@ export class AuthServiceMock {
 }
 
 export class TaskServiceMock {
-  
+
   getTasks(): Observable<Task[]> {
     return Observable.of([{
       id: 1,
@@ -56,7 +50,7 @@ export class TaskServiceMock {
       code: 'code',
       user: TestMethods.getTeacher(),
       results: null,
-      visibility: "OPEN"
+      visibility: <Visibility>'OPEN'
     }])
   }
 
@@ -66,7 +60,8 @@ export class TaskServiceMock {
       name: 'Tehtävä 1',
       code: 'code',
       creator: 'oppi.opettaja@koulu.fi',
-      resultItemCount: 1
+      resultItemCount: 1,
+      type: <TaskType>'INVESTIGATE'
     }])
   }
 
@@ -76,7 +71,7 @@ export class TaskServiceMock {
 }
 
 export class TaskTemplateServiceMock {
-  
+
   getTaskTemplate(): Observable<TaskTemplate> {
     return Observable.of(this.getTemplate(1))
   }
@@ -91,14 +86,14 @@ export class TaskTemplateServiceMock {
 }
 
 export class OpsServiceMock {
-  
+
   getGrades(): Observable<Grade[]> {
     return Observable.of([TestMethods.getGradeWithId(1), TestMethods.getGradeWithId(1)])
   }
 }
 
 export class TestMethods {
-  
+
   static getTeacher(): User {
     return {
       username: 'oppi.opettaja@koulu.fi',


### PR DESCRIPTION
- Angular 5 compiler is stricter when checking templates and that is
why almost every test was failing.
- Little code clean up.
- Prevent oskari-rpc component (map) showing before task is loaded.